### PR TITLE
fix: dryRunフラグのロジックを修正

### DIFF
--- a/functions/scraping-lambda/src/handlers/handlers.ts
+++ b/functions/scraping-lambda/src/handlers/handlers.ts
@@ -74,9 +74,10 @@ export const workPunch = async (
   const jobcan = new JobCanClient(page);
   await jobcan.login(userId, plaintext);
 
-  if (dryRun) return 0;
-  const res = await jobcan.workPunch();
-  logger.info(res);
+  if (dryRun === false) {
+    const res = await jobcan.workPunch();
+    logger.info(res);
+  }
 
   const workingHours = await jobcan.getWorkingHours();
   logger.info(workingHours);


### PR DESCRIPTION
## Summary
- `dryRun=true` の時は打刻をスキップし、`dryRun=false` の時のみ実際に打刻するよう修正
- 変更前は早期リターンで勤怠時間の取得もスキップされていたが、`dryRun=true` の場合も勤怠時間の取得は行うように変更

## Test plan
- [ ] `DRY_RUN=true` の環境で打刻がスキップされることを確認
- [ ] `DRY_RUN=false` の環境で打刻が正常に実行されることを確認
- [ ] `DRY_RUN=true` の環境で勤怠時間の取得が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)