### PR TITLE
feat: jobcan-scraping-lambdaロールにpuppeteer-zac-work-register SNSパブリッシュ権限を追加

### DIFF
--- a/deployment/serverless.dev.yml
+++ b/deployment/serverless.dev.yml
@@ -20,3 +20,4 @@ environment:
   scraping:
     KMS_CUSTOMER_KEY_ARN: arn:aws:kms:ap-northeast-1:105785188161:key/9f99a548-b1a4-402b-8e2d-07c91d5b46eb
     KMS_CUSTOMER_ALIAS_KEY_ARN: arn:aws:kms:ap-northeast-1:105785188161:alias/jobcan-customer-key-dev
+    ZAC_REGISTER_EVENT_TOPIC_ARN: arn:aws:sns:ap-northeast-1:105785188161:puppeteer-zac-work-register-dev

--- a/terraform/modules/aws/iam-policy.tf
+++ b/terraform/modules/aws/iam-policy.tf
@@ -111,5 +111,25 @@ resource "aws_iam_policy" "jobcan-api-read-user-attributes-policy" {
         Resource = aws_dynamodb_table.jobcan_user_attributes.arn
       }
     ]
-  })  
+  })
+}
+
+data "aws_sns_topic" "puppeteer-zac-work-register" {
+  name = "puppeteer-zac-work-register-${var.env}"
+}
+
+resource "aws_iam_policy" "jobcan-scraping-sns-zac-register-policy" {
+  name = "${var.app_name}-${var.env}-scraping-sns-zac-register-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "sns:Publish"
+        ]
+        Effect   = "Allow"
+        Resource = data.aws_sns_topic.puppeteer-zac-work-register.arn
+      }
+    ]
+  })
 }

--- a/terraform/modules/aws/iam-role-attachment.tf
+++ b/terraform/modules/aws/iam-role-attachment.tf
@@ -52,3 +52,8 @@ resource "aws_iam_role_policy_attachment" "jobcan-scraping-kms-lambda" {
   role = aws_iam_role.jobcan-scraping-lambda.name
   policy_arn = aws_iam_policy.jobcan-kms-policy.arn
 }
+
+resource "aws_iam_role_policy_attachment" "jobcan-scraping-sns-zac-register-lambda" {
+  role       = aws_iam_role.jobcan-scraping-lambda.name
+  policy_arn = aws_iam_policy.jobcan-scraping-sns-zac-register-policy.arn
+}


### PR DESCRIPTION
## Summary

- `jobcan-scraping-lambda` ロールに SNS トピック `puppeteer-zac-work-register-{env}` への `sns:Publish` 権限を追加
- Terraform の data source でトピック ARN を参照する IAM ポリシーを新規作成
- `serverless.dev.yml` に `ZAC_REGISTER_EVENT_TOPIC_ARN` 環境変数を追加

## Test plan

- [ ] `terraform plan` で差分が意図通りであることを確認
- [ ] `terraform apply` 後、scraping Lambda から SNS パブリッシュが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)