### PR TITLE
feat: publishZacRegisterEventの引数を配列に変更

### DIFF
--- a/functions/scraping-lambda/src/lib/sns.ts
+++ b/functions/scraping-lambda/src/lib/sns.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { SNSClient, PublishCommand } from '@aws-sdk/client-sns';
 import { SnsEventSchema } from '../entities/zac.ts';
 
-export const publishZacRegisterEvent = async (event: z.infer<typeof SnsEventSchema>) => {
+export const publishZacRegisterEvent = async (event: z.infer<typeof SnsEventSchema>[]) => {
   const sns = new SNSClient({});
 
   await sns.send(


### PR DESCRIPTION
## Summary

- `publishZacRegisterEvent` の引数の型を `SnsEventSchema` から `SnsEventSchema[]` に変更
- 複数のイベントをまとめて SNS に publish できるようにする

## Test plan

- [ ] scraping Lambda から複数イベントを SNS パブリッシュできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)