### PR TITLE
fix: SQSキュー名をzac-queue.fifoに修正しMessageGroupIdを追加

### DIFF
--- a/deployment/serverless.dev.yml
+++ b/deployment/serverless.dev.yml
@@ -20,4 +20,4 @@ environment:
   scraping:
     KMS_CUSTOMER_KEY_ARN: arn:aws:kms:ap-northeast-1:105785188161:key/9f99a548-b1a4-402b-8e2d-07c91d5b46eb
     KMS_CUSTOMER_ALIAS_KEY_ARN: arn:aws:kms:ap-northeast-1:105785188161:alias/jobcan-customer-key-dev
-    ZAC_REGISTER_EVENT_QUEUE_URL: https://sqs.ap-northeast-1.amazonaws.com/105785188161/zac-sqs-queue
+    ZAC_REGISTER_EVENT_QUEUE_URL: https://sqs.ap-northeast-1.amazonaws.com/105785188161/zac-queue.fifo

--- a/functions/scraping-lambda/src/lib/sqs.ts
+++ b/functions/scraping-lambda/src/lib/sqs.ts
@@ -9,6 +9,7 @@ export const sendZacRegisterEvent = async (event: z.infer<typeof SqsEventSchema>
     new SendMessageCommand({
       QueueUrl: process.env.ZAC_REGISTER_EVENT_QUEUE_URL,
       MessageBody: JSON.stringify(event),
+      MessageGroupId: 'zac-register',
     }),
   );
 };

--- a/terraform/modules/aws/iam-policy.tf
+++ b/terraform/modules/aws/iam-policy.tf
@@ -115,7 +115,7 @@ resource "aws_iam_policy" "jobcan-api-read-user-attributes-policy" {
 }
 
 data "aws_sqs_queue" "puppeteer-zac-work-register" {
-  name = "zac-sqs-queue"
+  name = "zac-queue.fifo"
 }
 
 resource "aws_iam_policy" "jobcan-scraping-sqs-zac-register-policy" {


### PR DESCRIPTION
## Summary
- TerraformのSQSキュー名を `zac-sqs-queue` → `zac-queue.fifo` に修正
- Lambda環境変数のQueue URLを `zac-queue.fifo` に修正
- FIFOキュー必須の `MessageGroupId` を `SendMessageCommand` に追加

## Test plan
- [ ] Terraform applyでSQSキューの参照が正常に解決されることを確認
- [ ] Lambda実行時にFIFOキューへメッセージが送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)