### PR TITLE
fix: 労働時間の小数点2桁目を切り捨て、send-zac-sqsスクリプトを追加

### DIFF
--- a/functions/scraping-lambda/package.json
+++ b/functions/scraping-lambda/package.json
@@ -7,7 +7,8 @@
     "build": "tsx build.ts",
     "lint": "eslint",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "execute": "node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' src/execute.ts"
+    "execute": "node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' src/execute.ts",
+    "send-zac-sqs": "node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' --env-file=.env src/send-zac-sqs.ts"
   },
   "type": "module",
   "keywords": [],

--- a/functions/scraping-lambda/src/playwright/jobcan.ts
+++ b/functions/scraping-lambda/src/playwright/jobcan.ts
@@ -61,7 +61,7 @@ export class JobCanClient {
    */
   private convertTimeToDecimal(time: string): number {
     const [hours, minutes] = time.split(":").map(Number);
-    return hours + minutes / 60;
+    return Math.floor((hours + minutes / 60) * 10) / 10;
   }
 
   async getWorkingHours(): Promise<number> {

--- a/functions/scraping-lambda/src/send-zac-sqs.ts
+++ b/functions/scraping-lambda/src/send-zac-sqs.ts
@@ -1,0 +1,23 @@
+import { ZacClient } from "./services/zac.ts";
+
+const [tenantId, loginId, password, workingTimeStr] = process.argv.slice(2);
+
+if (!tenantId || !loginId || !password || !workingTimeStr) {
+  console.error(
+    "Usage: npm run send-zac-sqs -- <tenantId> <loginId> <password> <workingTime>",
+  );
+  console.error("Example: npm run send-zac-sqs -- my-tenant user1 pass123 8.5");
+  process.exit(1);
+}
+
+const workingTime = parseFloat(workingTimeStr);
+if (isNaN(workingTime) || workingTime <= 0) {
+  console.error("workingTime must be a positive number");
+  process.exit(1);
+}
+
+console.log(`Sending ZAC register event: tenantId=${tenantId}, loginId=${loginId}, workingTime=${workingTime}`);
+
+await new ZacClient(tenantId, loginId, password).zacRegisterEvent(workingTime);
+
+console.log("Message sent successfully.");


### PR DESCRIPTION
## Summary
- 労働時間の表示で小数点以下が長くなる問題を修正（例: `9.433...` → `9.4`）
- `convertTimeToDecimal`で`Math.floor`を使い小数点1桁に切り捨て
- ZAC SQS送信用の実行スクリプト(`send-zac-sqs`)をpackage.jsonに追加
- `send-zac-sqs.ts`ファイルを追加

## Test plan
- [ ] 労働時間が小数点1桁で表示されることを確認（例: 9:26 → 9.4）
- [ ] send-zac-sqsスクリプトが正常に実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)