### PR TITLE
feat: dev デプロイに workflow_dispatch を追加

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - deployment/develop
+  workflow_dispatch:
 jobs:
   create-hash:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- dev デプロイワークフローに `workflow_dispatch` トリガーを追加
- feature ブランチから手動で dev 環境へデプロイ可能にする

## Test plan
- [ ] GitHub Actions UI から任意のブランチを指定して deploy-dev を手動実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)