### PR TITLE
feat: 労働時間取得Lambda(getWorkingHours)を追加

### DIFF
--- a/functions/scraping-lambda/src/entities/jobcan.ts
+++ b/functions/scraping-lambda/src/entities/jobcan.ts
@@ -13,3 +13,9 @@ export interface ScrapingPayload {
   zac_password: string;
   choice_work_type: string;
 }
+
+export interface GetWorkingHoursPayload {
+  jobcan_user_id: string;
+  jobcan_password: string;
+  date?: string;
+}

--- a/functions/scraping-lambda/src/handlers/handlers.ts
+++ b/functions/scraping-lambda/src/handlers/handlers.ts
@@ -4,7 +4,7 @@ import { getBrowser } from "../lib/browser.ts";
 
 import { JobCanClient } from "../playwright/jobcan.ts";
 import { type Browser } from "playwright";
-import { ScrapingPayload } from "../entities/jobcan.ts";
+import { GetWorkingHoursPayload, ScrapingPayload } from "../entities/jobcan.ts";
 import { decryptPassword } from "../lib/kms.ts";
 import { sendSlackNotification } from "../slack/notification.ts";
 import { ZacClient } from "../services/zac.ts";
@@ -82,4 +82,30 @@ export const workPunch = async (
   const workingHours = await jobcan.getWorkingHours();
   logger.info(workingHours);
   return workingHours;
+};
+
+export const getWorkingHoursHandler = async (
+  event: GetWorkingHoursPayload,
+): Promise<number> => {
+  const { jobcan_user_id: userId, jobcan_password: password, date } = event;
+
+  logger.info("start get working hours");
+
+  const browser = await getBrowser();
+
+  try {
+    const page = await browser.newPage();
+    const plaintext = (await decryptPassword(password)).toString();
+
+    const jobcan = new JobCanClient(page);
+    await jobcan.login(userId, plaintext);
+
+    const workingHours = await jobcan.getWorkingHours(date);
+    logger.info(`working hours: ${workingHours}`);
+
+    return workingHours;
+  } finally {
+    await browser.close();
+    logger.info("end get working hours");
+  }
 };

--- a/functions/scraping-lambda/src/playwright/jobcan.ts
+++ b/functions/scraping-lambda/src/playwright/jobcan.ts
@@ -64,26 +64,32 @@ export class JobCanClient {
     return Math.floor((hours + minutes / 60) * 10) / 10;
   }
 
-  async getWorkingHours(): Promise<number> {
+  async getWorkingHours(date?: string): Promise<number> {
     try {
+      const targetDate = date ? new Date(date) : new Date();
+      const year = targetDate.getFullYear();
+      const month = targetDate.getMonth() + 1;
+
       await this.page.goto("https://ssl.jobcan.jp/jbcoauth/login");
 
-      // 打刻修正ページにアクセス
-      await this.page.goto("https://ssl.jobcan.jp/employee/attendance");
+      // 対象年月の勤怠ページにアクセス
+      await this.page.goto(
+        `https://ssl.jobcan.jp/employee/attendance?list_type=normal&search_type=month&year=${year}&month=${month}`,
+      );
 
-      // 当日の日付を取得 (MM/DD形式)
-      const today = format(new Date(), "MM/dd");
+      // 対象日の日付を取得 (MM/DD形式)
+      const targetDay = format(targetDate, "MM/dd");
 
-      // 当日の行を特定
-      const todayRow = this.page.locator(`tr:has(td:has-text("${today}"))`);
-      const isVisible = await todayRow.isVisible();
+      // 対象日の行を特定
+      const targetRow = this.page.locator(`tr:has(td:has-text("${targetDay}"))`);
+      const isVisible = await targetRow.isVisible();
 
       if (!isVisible) {
-        throw new Error("当日の勤務データが見つかりませんでした");
+        throw new Error(`${targetDay}の勤務データが見つかりませんでした`);
       }
 
       // 労働時間を取得 (7番目のtd要素)
-      const workingHours = await todayRow.locator("td").nth(6).innerText();
+      const workingHours = await targetRow.locator("td").nth(6).innerText();
 
       if (!workingHours) {
         logger.warn("労働時間が取得できませんでした");

--- a/serverless.yml
+++ b/serverless.yml
@@ -48,3 +48,14 @@ functions:
     events:
       - sqs:
           arn: ${file(deployment/serverless.${opt:stage}.yml):deploy.sqs.punch-work-queue.arn}
+  getWorkingHours:
+    name: ${self:service}-get-working-hours-${self:provider.stage}
+    image:
+      name: jobcan-tools-scraping
+      command:
+        - dict/handlers/handlers.getWorkingHoursHandler
+      entryPoint:
+        - "/lambda-entrypoint.sh"
+    role: ${file(deployment/serverless.${opt:stage}.yml):iam-role.scraping}
+    environment: ${file(deployment/serverless.${opt:stage}.yml):environment.scraping}
+    timeout: 60


### PR DESCRIPTION
## Summary
- AWS内部から同期Invokeで呼び出す前提の労働時間取得Lambda(`jobcan-tools-get-working-hours-${stage}`)を追加
- `JobCanClient.getWorkingHours` を `date?: string`(`YYYY-MM-DD`)対応に拡張。URLパラメータ(`year`/`month`)で過去月も取得可能
- payload は `{ jobcan_user_id, jobcan_password(KMS暗号化済み), date? }`、レスポンスは数値(10進労働時間)

## アーキテクチャ
- 呼び出し元 Lambda(別プロジェクト)から AWS SDK の `InvokeCommand` で同期呼び出し
- 認証はIAM(`lambda:InvokeFunction`)のみ。アプリ層の認証は持たない
- 既存 `scraping-lambda` のコンテナイメージを再利用

## Test plan
- [ ] `npx tsc --noEmit` で型エラーがないことを確認
- [ ] dev環境にデプロイし、当日(date省略)で正しい労働時間が返ることを確認
- [ ] 過去月の日付を指定し、その日の労働時間が返ることを確認
- [ ] 存在しない日付を指定した場合にエラーになることを確認(スナップショットがS3に保存されること)
- [ ] 別Lambdaから `lambda:InvokeFunction` 権限付きで同期Invokeできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)