### PR TITLE
chore: 労働時間取得のローカル実行スクリプトを追加

### DIFF
--- a/functions/scraping-lambda/package.json
+++ b/functions/scraping-lambda/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "execute": "node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' src/execute.ts",
+    "execute-get-working-hours": "HEADLESS_MODE=true node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' --env-file=.env src/execute-get-working-hours.ts",
     "send-zac-sqs": "node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' --env-file=.env src/send-zac-sqs.ts"
   },
   "type": "module",

--- a/functions/scraping-lambda/src/execute-get-working-hours.ts
+++ b/functions/scraping-lambda/src/execute-get-working-hours.ts
@@ -1,0 +1,29 @@
+import { getBrowser } from "./lib/browser.ts";
+import { JobCanClient } from "./playwright/jobcan.ts";
+import logger from "./lib/logger.ts";
+
+const {
+  JOBCAN_SCRAPING_LAMBDA_USER,
+  JOBCAN_SCRAPING_LAMBDA_PASSWORD,
+  TARGET_DATE,
+} = process.env;
+
+if (!JOBCAN_SCRAPING_LAMBDA_USER || !JOBCAN_SCRAPING_LAMBDA_PASSWORD) {
+  throw new Error("Environment variables are not set");
+}
+
+const browser = await getBrowser();
+
+try {
+  const page = await browser.newPage();
+  const jobcan = new JobCanClient(page);
+  await jobcan.login(
+    JOBCAN_SCRAPING_LAMBDA_USER,
+    JOBCAN_SCRAPING_LAMBDA_PASSWORD,
+  );
+
+  const workingHours = await jobcan.getWorkingHours(TARGET_DATE);
+  logger.info(`working hours: ${workingHours}`);
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## Summary
- PR #23 で追加した `getWorkingHoursHandler` をローカルで動作確認するための実行スクリプトを追加
- `JobCanClient.getWorkingHours` を直接呼び出す形式(KMS復号は介さない)

## 変更内容
- `functions/scraping-lambda/src/execute-get-working-hours.ts`(新規): ヘッドレスChromiumでログイン → 労働時間取得をローカル実行
- `functions/scraping-lambda/package.json`: `execute-get-working-hours` スクリプト追加(`HEADLESS_MODE=true`)
- `TARGET_DATE` 環境変数(`YYYY-MM-DD`)で対象日を指定可能。未指定時は当日

## 使い方
```bash
cd functions/scraping-lambda
# 当日
npm run execute-get-working-hours
# 過去日
TARGET_DATE=2026-04-25 npm run execute-get-working-hours
```

## Test plan
- [x] 当日(date省略)で正しい労働時間が返ることを確認(動作確認済み: `working hours: 7.5`)
- [ ] 過去日付(`TARGET_DATE`指定)で正しい労働時間が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)