### PR TITLE
chore: 労働時間取得時のデバッグログを追加

### DIFF
--- a/functions/scraping-lambda/package.json
+++ b/functions/scraping-lambda/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "execute": "node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' src/execute.ts",
+    "execute-get-working-hours": "HEADLESS_MODE=true node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' --env-file=.env src/execute-get-working-hours.ts",
     "send-zac-sqs": "node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' --env-file=.env src/send-zac-sqs.ts"
   },
   "type": "module",

--- a/functions/scraping-lambda/src/execute-get-working-hours.ts
+++ b/functions/scraping-lambda/src/execute-get-working-hours.ts
@@ -1,0 +1,29 @@
+import { getBrowser } from "./lib/browser.ts";
+import { JobCanClient } from "./playwright/jobcan.ts";
+import logger from "./lib/logger.ts";
+
+const {
+  JOBCAN_SCRAPING_LAMBDA_USER,
+  JOBCAN_SCRAPING_LAMBDA_PASSWORD,
+  TARGET_DATE,
+} = process.env;
+
+if (!JOBCAN_SCRAPING_LAMBDA_USER || !JOBCAN_SCRAPING_LAMBDA_PASSWORD) {
+  throw new Error("Environment variables are not set");
+}
+
+const browser = await getBrowser();
+
+try {
+  const page = await browser.newPage();
+  const jobcan = new JobCanClient(page);
+  await jobcan.login(
+    JOBCAN_SCRAPING_LAMBDA_USER,
+    JOBCAN_SCRAPING_LAMBDA_PASSWORD,
+  );
+
+  const workingHours = await jobcan.getWorkingHours(TARGET_DATE);
+  logger.info(`working hours: ${workingHours}`);
+} finally {
+  await browser.close();
+}

--- a/functions/scraping-lambda/src/playwright/jobcan.ts
+++ b/functions/scraping-lambda/src/playwright/jobcan.ts
@@ -69,6 +69,11 @@ export class JobCanClient {
       const targetDate = date ? new Date(date) : new Date();
       const year = targetDate.getFullYear();
       const month = targetDate.getMonth() + 1;
+      const targetDay = format(targetDate, "MM/dd");
+
+      logger.info(
+        `get working hours target: year=${year}, month=${month}, day=${targetDay}`,
+      );
 
       await this.page.goto("https://ssl.jobcan.jp/jbcoauth/login");
 
@@ -76,9 +81,6 @@ export class JobCanClient {
       await this.page.goto(
         `https://ssl.jobcan.jp/employee/attendance?list_type=normal&search_type=month&year=${year}&month=${month}`,
       );
-
-      // 対象日の日付を取得 (MM/DD形式)
-      const targetDay = format(targetDate, "MM/dd");
 
       // 対象日の行を特定
       const targetRow = this.page.locator(`tr:has(td:has-text("${targetDay}"))`);
@@ -90,9 +92,10 @@ export class JobCanClient {
 
       // 労働時間を取得 (7番目のtd要素)
       const workingHours = await targetRow.locator("td").nth(6).innerText();
+      logger.info(`raw working hours text: "${workingHours}"`);
 
       if (!workingHours) {
-        logger.warn("労働時間が取得できませんでした");
+        logger.warn(`${targetDay}の労働時間が取得できませんでした`);
         return 0;
       }
 


### PR DESCRIPTION
## Summary
- `JobCanClient.getWorkingHours` で労働時間が取得できなかった際の原因切り分け用にログを追加
- 対象年月日とtdから取得した生テキストをinfoログに出力
- warnメッセージに対象日を含めて、どの日の労働時間が取れなかったか分かるように

## 背景
PR #23 のマージ後に動作確認したところ、当日のwarn(`労働時間が取得できませんでした`)だけ出て原因が特定できなかったため、ログを強化。

## Test plan
- [x] ローカル実行で対象日付・生テキストがログに出ることを確認
  ```
  info: get working hours target: year=2026, month=4, day=04/29
  info: raw working hours text: ""
  warn: 04/29の労働時間が取得できませんでした
  ```

## 注意
このPRは PR #24(`feature/add-get-working-hours-local-script`)から派生しているため、PR #24 がマージされる前は PR #24 の変更も差分に含まれます。PR #24 → 本PRの順でマージしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)